### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,5 +1,8 @@
 name: Lint Code Base
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/ftnick/SpiWare/security/code-scanning/3](https://github.com/ftnick/SpiWare/security/code-scanning/3)

The best way to fix this issue is to explicitly define the `permissions` block at the workflow level to ensure minimal privileges are granted. Based on the current workflow, it primarily checks out the code and runs linting. Therefore, the minimal necessary permissions appear to be `contents: read`.

- Add a `permissions` block at the root level of the workflow to set the permissions for all jobs to `contents: read`.
- This ensures the workflow does not inadvertently rely on repository-level permissions and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
