### PR TITLE
(#6) Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/enforce-pr-title.yml
+++ b/.github/workflows/enforce-pr-title.yml
@@ -1,11 +1,13 @@
-permissions:
-  contents: read
-  pull-requests: read
+---
 name: Enforce PR Title Format
 
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   check-title:
@@ -14,10 +16,10 @@ jobs:
       - name: Check PR title format
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          NUMBER=${{ github.event.pull_request.number }}
-          
+          NUMBER=${{ github.event.pull_request.number }}"
+
           echo "PR Title: $TITLE"
-          
+
           if [[ "$TITLE" != *"(#${NUMBER})"* ]]; then
             echo "::error ::PR title must include '(#${NUMBER})' to be used as squash commit message"
             exit 1

--- a/.github/workflows/enforce-pr-title.yml
+++ b/.github/workflows/enforce-pr-title.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: read
 name: Enforce PR Title Format
 
 on:

--- a/.github/workflows/enforce-pr-title.yml
+++ b/.github/workflows/enforce-pr-title.yml
@@ -16,11 +16,13 @@ jobs:
       - name: Check PR title format
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          NUMBER=${{ github.event.pull_request.number }}"
+          NUMBER="${{ github.event.pull_request.number }}"
 
           echo "PR Title: $TITLE"
 
-          if [[ "$TITLE" != *"(#${NUMBER})"* ]]; then
-            echo "::error ::PR title must include '(#${NUMBER})' to be used as squash commit message"
+          REQUIRED_PART="(#${NUMBER})"
+
+          if [[ "$TITLE" != *"$REQUIRED_PART"* ]]; then
+            echo "::error ::PR title must include '$REQUIRED_PART' to be used as squash commit message"
             exit 1
           fi


### PR DESCRIPTION
Potential fix for [https://github.com/ftnick/SpiWare/security/code-scanning/4](https://github.com/ftnick/SpiWare/security/code-scanning/4)

To fix the issue, add a `permissions` block at the workflow level, as this applies the specified permissions to all jobs in the workflow (including `check-title`). Since the workflow only reads pull request data (title and number), it requires `contents: read` and `pull-requests: read` permissions. This configuration adheres to the principle of least privilege.

The changes will be made at the root level of the workflow file, immediately after the `name` field, ensuring that the GITHUB_TOKEN used in this workflow has only the necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
